### PR TITLE
MTG CFE instead of MUG in

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -53,7 +53,7 @@
                         <a href="https://www.lavajug.org" class="social" rel="noreferrer" target="_blank">LavaJUG</a>
                     </li>
                     <li>
-                        <a href="http://muginclermont.azurewebsites.net/#" class="social" rel="noreferrer" target="_blank">MugInClermont</a>
+                        <a href="https://www.meetup.com/fr-FR/mtg-clermont-ferrand/" class="social" rel="noreferrer" target="_blank">MTG Clermont-Ferrand</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
Mug'In clermont has been renammed. it is now MTG Clermont-Ferrand