### PR TITLE
Add site name to webmanifest file

### DIFF
--- a/asset/images/favicon/site.webmanifest
+++ b/asset/images/favicon/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Volcamp",
+    "short_name": "Volcamp",
     "icons": [
         {
             "src": "/asset/images/icons/android-chrome-192x192.png",


### PR DESCRIPTION
When installing the Volcamp website as a PWA, the name displayed on the app IS "website" instead of Volcamp