### PR TITLE
talks: remove invalid category into the speaker field

### DIFF
--- a/_talks/24d2t1s8.md
+++ b/_talks/24d2t1s8.md
@@ -3,7 +3,7 @@
   title: Créer un browser from scratch, c'est possible ?
   category: Découverte
   format: Conférence
-  speakers: Découverte
+  speakers:
     - Pierre Tachoire
   room: Auditorium
   slot: 11/10/2024


### PR DESCRIPTION
The link with the speaker was broken on https://www.volcamp.io/talks/24d2t1s8

![Screenshot from 2024-09-13 11-18-54](https://github.com/user-attachments/assets/46ac45a2-385c-482f-9a67-827f014eec8a)
